### PR TITLE
Fix bool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,6 @@ script:
     - python -m doctest pretext.py
     - python -m doctest tests/test_prefixrepr.py
     - python -m doctest tests/test_displayhook.py
+    - python -m doctest tests/test_activate.py
     - python tests/test_xrepr.py
 

--- a/pretext.py
+++ b/pretext.py
@@ -51,6 +51,9 @@ class Repr(reprlib.Repr):
         self.maxtuple = sys.maxsize
         self.maxother = sys.maxsize
 
+    def repr_bool(self, obj, level):
+        return '%s' % obj
+
 
 class PrefixRepr(Repr):
     """A Repr that always prefixes any string, and doesn't truncate

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1,0 +1,55 @@
+"""
+>>> import sys, pretext
+>>> pretext.activate()
+>>> bytes()
+b''
+>>> b'0123456789'
+b'0123456789'
+>>> u'0123456789'
+'0123456789'
+"""
+
+
+def str_func():
+    """
+    This function's doctest does not override displayhook, thus checking
+    that other doctests do not leak their sys.displayhook override.
+
+    >>> str_func()
+    'I return a native str'
+    """
+    return 'I return a native str'
+
+
+def bytes_func():
+    """
+    >>> import sys, pretext
+    >>> pretext.activate()
+    >>> bytes_func()
+    b'I return a byte string'
+    """
+    return b'I return a byte string'
+
+
+def textual_func():
+    """
+    >>> import sys, pretext
+    >>> pretext.activate(pretext.urepr, pretext.udisplayhook)
+    >>> textual_func()
+    u'I return a textual (unicode) string'
+    """
+    return u'I return a textual (unicode) string'
+
+def bool_func(rv):
+    """
+    >>> import sys, pretext; pretext.activate()
+    >>> bool_func(True)
+    True
+    >>> bool_func(False)
+    False
+    >>> 1 == 1
+    True
+    >>> 1 == 2
+    False
+    """
+    return rv

--- a/tests/test_xrepr.py
+++ b/tests/test_xrepr.py
@@ -57,6 +57,39 @@ class Python3TestCase(unittest.TestCase):
         self.assertEqual('u'+repr(s), prepr(s))
 
 
+class NoChangeTestCase(unittest.TestCase):
+
+    @given(st.none())
+    def test_none(self, s):
+        self.assertEqual(repr(s), brepr(s))
+        self.assertEqual(repr(s), prepr(s))
+        self.assertEqual(repr(s), urepr(s))
+
+    @given(st.booleans())
+    def test_bool(self, s):
+        self.assertEqual(repr(s), brepr(s))
+        self.assertEqual(repr(s), prepr(s))
+        self.assertEqual(repr(s), urepr(s))
+
+    @given(st.integers())
+    def test_int(self, s):
+        self.assertEqual(repr(s), brepr(s))
+        self.assertEqual(repr(s), prepr(s))
+        self.assertEqual(repr(s), urepr(s))
+
+    @given(st.floats())
+    def test_float(self, s):
+        self.assertEqual(repr(s), brepr(s))
+        self.assertEqual(repr(s), prepr(s))
+        self.assertEqual(repr(s), urepr(s))
+
+    @given(st.complex_numbers())
+    def test_complex(self, s):
+        self.assertEqual(repr(s), brepr(s))
+        self.assertEqual(repr(s), prepr(s))
+        self.assertEqual(repr(s), urepr(s))
+
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
The following doctest created unusual results on both Python 2 & 3

```
>>> True
True
```

Also add tests for other types that should not be impacted
by the pretext hack.
